### PR TITLE
Deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # intercom-ios
 
 > **Warning**  
-> This repository is now deprecated. Please migrate to [Intercom's official Swift Package repository](https://github.com/intercom/intercom-ios-sp/tree/master) which resolves the size issue.
+> This repository is now deprecated. Please migrate to [Intercom's official Swift Package repository](https://github.com/intercom/intercom-ios-sp) which resolves the size issue.
 
 A Swift Package for the [Intercom iOS SDK](https://github.com/intercom/intercom-ios), because their repository is ~[2.0GB](https://api.github.com/repos/intercom/intercom-ios).
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # intercom-ios
 
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FFelixHerrmann%2Fintercom-ios%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/FelixHerrmann/intercom-ios)
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FFelixHerrmann%2Fintercom-ios%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/FelixHerrmann/intercom-ios)
-[![Version](https://img.shields.io/github/v/release/FelixHerrmann/intercom-ios)](https://github.com/FelixHerrmann/intercom-ios/releases)
-[![License](https://img.shields.io/github/license/FelixHerrmann/intercom-ios)](https://github.com/FelixHerrmann/intercom-ios/blob/master/LICENSE)
-[![Tweet](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Fgithub.com%2FFelixHerrmann%2Fintercom-ios)](https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2FFelixHerrmann%2Fintercom-ios)
+> **Warning**  
+> This repository is now deprecated. Please migrate to [Intercom's official Swift Package repository](https://github.com/intercom/intercom-ios-sp/tree/master) which resolves the size issue.
 
 A Swift Package for the [Intercom iOS SDK](https://github.com/intercom/intercom-ios), because their repository is ~[2.0GB](https://api.github.com/repos/intercom/intercom-ios).
 
-> This repository updates itself; every hour the [update-workflow](https://github.com/FelixHerrmann/intercom-ios/actions/workflows/update.yml) runs
-> and checks for a new version.
-
-
-# License
+## License
 
 intercom-ios is available under the MIT license. See the [LICENSE](https://github.com/FelixHerrmann/intercom-ios/blob/master/LICENSE) file for more info.


### PR DESCRIPTION
There is now an [official solution](https://github.com/intercom/intercom-ios-sp) provided by Intercom which make this repository pointless. This PR adds a deprecation notice on the REAMDE. I will also remove this repository from the [Swift Package Index](https://swiftpackageindex.com/FelixHerrmann/intercom-ios). Furthermore with the next released version of the Intercom SDK (15.0.4 or similar) I will archive this repository!